### PR TITLE
Try getitem caching

### DIFF
--- a/ambiguous/dataset/dataset.py
+++ b/ambiguous/dataset/dataset.py
@@ -16,6 +16,7 @@ import numpy as np
 from tqdm import tqdm
 import yaml
 import glob
+import functools
 import subprocess
 import urllib.request
 from torch.utils.data import *
@@ -90,6 +91,7 @@ class DatasetTriplet(Dataset):
         self.data_len = len(self.image_list)
         self.transform = transform
 
+    @functools.cache
     def __getitem__(self, index, img_size=28):
         single_image_path = self.image_list[index]
         im_as_np = np.load(single_image_path).astype(np.float64)/255.


### PR DESCRIPTION
This simple little change improves ds read speed considerable on the 2nd pass according to my tests. 
It requires python >=3.9
It is also worth noting that the cache is created in isolation for dataloader workers, and reset each iteration, so the cache needs to be created outside of the dataloader by iterating once through the dataset itself to see an effect.

dataset.__getitem__.cache_info() gets status of the cache
dataset.__getitem__cache_clear() clears it.

